### PR TITLE
Added build_sleuthkit script and db setup instructions

### DIFF
--- a/build_sleuthkit
+++ b/build_sleuthkit
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# Shell script to build Sleuth Kit Framework
+# Copyright (C) 2015 Philip Lindner
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# Script for downloading, compiling and installing Sleuth Kit Framework
+# Command line options:
+# 	-p (--package-check)	Check if needed packages (git, make, 
+# 				autoconf, automake, libtool) are installed
+# 	-w (--whitespace-check)	Check the absolute path for whitespace
+#				characters which would cause make to fail
+
+
+# Core functionality - clone, build and install
+function build() {
+	git clone https://github.com/sleuthkit/sleuthkit.git sleuthkit_recent
+	cd sleuthkit_recent
+	./bootstrap
+	./configure
+	make
+	echo $1 | sudo -S make install
+}
+
+# Check the absolute path for whitespaces
+# When this was written, such a whitespace would cause -make- to fail
+function check_path_for_whitespaces() {
+	ABSOLUTE_PATH=$(readlink -f .)
+	for (( i=0; i<${#ABSOLUTE_PATH}; i++ )); do
+		if [ "${ABSOLUTE_PATH:$i:1}" = " " ]; then
+			echo "Warning: Your path contains a whitespace!"
+			echo "This may cause -make- to fail during compilation"
+			break
+		fi
+	done
+}
+
+# Check if all required packages are installed
+# These packages aren't explicity checked for in the configure script
+function check_packages() {
+
+	REQ_PACKAGES=("git" "make" "autoconf" "automake" "libtool")
+	INSTALLED_MANAGERS=()
+
+	# Commands for checking if packet manager exists
+	DPKGPROBE="dpkg-query -W > /dev/null 2>&1"
+	RPMPROBE="rpm -qa > /dev/null 2>&1"
+
+	# Commands for fetching a list of installed packages
+	DPKGLIST="dpkg-query -f '\${binary:Package}\n' -W"
+	RPMLIST="rpm -qa"
+
+	# Checking which packet manager(s) is (are) installed
+	eval $DPKGPROBE
+	if [ "$?" = "0" ]; then
+		INSTALLED_MANAGERS+=(DPKGLIST)
+	fi
+
+	eval $RPMPROBE
+	if [ "$?" = "0" ]; then
+		INSTALLED_MANAGERS+=(RPMLIST)
+	fi
+
+	ALLFOUND=1
+	for i in ${REQ_PACKAGES[@]}; do
+		FOUND_PACK=0
+		for manager in ${INSTALLED_MANAGERS[@]}; do
+			if [ "$(eval \$$manager | grep $i)" != "" ]; then
+				FOUND_PACK=1
+			fi
+		done
+		if [ "$FOUND_PACK" = 0 ]; then
+			echo "The package $i needs to be installed to compile dependencies!"
+			ALLFOUND=0
+		fi
+	done
+
+	if [ "$ALLFOUND" = 0 ]; then
+		echo "Your system is missing some packages required for compilation."
+		echo "Please install these packages and run this script again."
+		exit 1
+	fi
+}
+
+CHECK_PACKAGES=0
+CHECK_WHITESPACE=0
+SHOULD_INSTALL=1
+
+# Check for command line options
+while [ "$1" != "" ]; do
+	case $1 in
+		-p | --package-check)
+			CHECK_PACKAGES=1
+			shift;&
+		-w | --whitespace-check)
+			CHECK_WHITESPACE=1
+			shift;;
+	esac
+done
+
+echo -n "Enter your sudo password: "
+read -s PASSWORD
+echo ""
+
+if [ "$CHECK_WHITESPACE" = 1 ]; then
+	check_path_for_whitespaces
+fi
+
+if [ "$CHECK_PACKAGES" = 1 ]; then
+	check_packages
+fi
+
+build $PASSWORD
+

--- a/db/README.md
+++ b/db/README.md
@@ -1,4 +1,7 @@
 # Setting up the database
+In the following, the preparation of a database for use with OpenDF
+is going to be described.
+
 
 First, let's enter the mysql CLI:
 ```bash

--- a/db/README.md
+++ b/db/README.md
@@ -23,7 +23,7 @@ SOURCE OpenDF.sql
 ```
 
 Then just exit the mysql CLI:
-```sql
+```bash
 exit
 ```
 

--- a/db/README.md
+++ b/db/README.md
@@ -15,6 +15,7 @@ Then grant all DB privileges to him.
 ```sql
 CREATE USER IF NOT EXISTS 'OpenDFU'@'localhost' IDENTIFIED BY '123';
 GRANT ALL PRIVILEGES ON OpenDF.* TO 'OpenDFU'@'localhost';
+```
 
 Then, run the OpenDF.sql script to fill the database with tables:
 ```sql

--- a/db/README.md
+++ b/db/README.md
@@ -22,5 +22,10 @@ Then, run the OpenDF.sql script to fill the database with tables:
 SOURCE OpenDF.sql
 ```
 
+Then just exit the mysql CLI:
+```sql
+exit
+```
+
 Congratulations! You've successfully set up your database server for
 use with OpenDF!

--- a/db/SETUP.md
+++ b/db/SETUP.md
@@ -1,0 +1,25 @@
+# Setting up the database
+
+First, let's enter the mysql CLI:
+```bash
+mysql -u root -p
+```
+
+Create the OpenDF database if it doesn't exists:
+```sql
+CREATE DATABASE IF NOT EXISTS OpenDF;
+```
+
+Create the user OpenDFU and set his password to 123.
+Then grant all DB privileges to him.
+```sql
+CREATE USER IF NOT EXISTS 'OpenDFU'@'localhost' IDENTIFIED BY '123';
+GRANT ALL PRIVILEGES ON OpenDF.* TO 'OpenDFU'@'localhost';
+
+Then, run the OpenDF.sql script to fill the database with tables:
+```sql
+SOURCE OpenDF.sql
+```
+
+Congratulations! You've successfully set up your database server for
+use with OpenDF!


### PR DESCRIPTION
#### The build_sleuthkit script
In order for sleuthkit to be up-to-date when installing OpenDF, the build_sleuthkit script clones the latest sleuthkit sources and compiles and installs them.

#### Database setup
Additionally, there now are some instructions on how to set up the database server for use with OpenDF. These are located inside db/README.md.