### PR TITLE
Environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,11 @@ MAINTAINER SCoRe Lab Community <commuity@scorelab.org>
 
 RUN apt-get update
 
+ENV OPENDF_REPO https://github.com/scorelab/OpenDF.git
+ENV OPENDF_BRANCH setup-script
+
 RUN mkdir -p /home/OpenDF
-RUN git clone https://github.com/scorelab/OpenDF.git /home/OpenDF
+RUN git clone -b ${OPENDF_BRANCH:-"master"} ${OPENDF_REPO:-"https://github.com/scorelab/OpenDF.git"} /home/OpenDF
 RUN chmod 755 /home/OpenDF/scripts/setup.sh
 RUN /home/OpenDF/scripts/setup.sh
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,19 +4,17 @@ echo "Setup in progress!"
 
 cd /home/OpenDF
 
-# Generate a password for mysql using unix system time as source
-RAN_PW=$(date +%s | md5sum | base64 | head -c 16)
+# Command for generating a 16-character pseudo-random password using $RANDOM as source
+RAN_PW="echo -n $RANDOM | md5sum | base64 | head -c 16"
 
 # Set environment variables (or get them from docker if possible)
 SLEUTHKIT_REPO=${SLEUTHKIT_REPO:-"https://github.com/sleuthkit/sleuthkit.git"}
 
 MYSQL_USER=${MYSQL_USER:-"root"}
-MYSQL_PW=${MYSQL_PW:-"$RAN_PW"}
+MYSQL_PW=${MYSQL_PW:-"$(eval $RAN_PW)"}
 
 OPENDF_DB_USER=${OPENDF_DB_USER:-"OpenDFU"}
-OPENDF_DB_PW=${OPENDF_DB_PW:-"123"}
-
-echo "Mysql password set to: $MYSQL_PW"
+OPENDF_DB_PW=${OPENDF_DB_PW:-"$(eval $RAN_PW)"}
 
 
 echo "Installing tools!"
@@ -66,6 +64,8 @@ asadmin add-resources "OpenDF-web/src/main/setup/glassfish-resources.xml"
 
 asadmin deploy "OpenDF-ear/target/OpenDF-ear-1.0-SNAPSHOT.ear"
 
+echo "MySQL login: user ${MYSQL_USER}; password ${MYSQL_PW}"
+echo "Access to OpenDF database granted to: user ${OPENDF_DB_USER}; password ${OPENDF_DB_PW}"
 echo "OpenDF succefully deployed on http://$(/sbin/ip route|awk '/default/ { print $3 }'):8080/OpenDF-web-1.0-SNAPSHOT"
 
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -64,8 +64,8 @@ asadmin add-resources "OpenDF-web/src/main/setup/glassfish-resources.xml"
 
 asadmin deploy "OpenDF-ear/target/OpenDF-ear-1.0-SNAPSHOT.ear"
 
-echo "MySQL login: user ${MYSQL_USER}; password ${MYSQL_PW}"
-echo "Access to OpenDF database granted to: user ${OPENDF_DB_USER}; password ${OPENDF_DB_PW}"
+echo "[INFO] ----- MySQL login: user ${MYSQL_USER}; password ${MYSQL_PW} -----"
+echo "[INFO] ----- Access to OpenDF database granted to: user ${OPENDF_DB_USER}; password ${OPENDF_DB_PW} -----"
 echo "OpenDF succefully deployed on http://$(/sbin/ip route|awk '/default/ { print $3 }'):8080/OpenDF-web-1.0-SNAPSHOT"
 
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,11 +4,26 @@ echo "Setup in progress!"
 
 cd /home/OpenDF
 
+# Generate a password for mysql using unix system time as source
+RAN_PW=$(date +%s | md5sum | base64 | head -c 16)
+
+# Set environment variables (or get them from docker if possible)
+SLEUTHKIT_REPO=${SLEUTHKIT_REPO:-"https://github.com/sleuthkit/sleuthkit.git"}
+
+MYSQL_USER=${MYSQL_USER:-"root"}
+MYSQL_PW=${MYSQL_PW:-"$RAN_PW"}
+
+OPENDF_DB_USER=${OPENDF_DB_USER:-"OpenDFU"}
+OPENDF_DB_PW=${OPENDF_DB_PW:-"123"}
+
+echo "Mysql password set to: $MYSQL_PW"
+
+
 echo "Installing tools!"
 # Install maven, mysql, automake, libtool, libstdc++, make
-# The following two lines prevent mysql from asking for a password (it will be set to rooot)
-echo mysql-server mysql-server/root_password password rooot | debconf-set-selections
-echo mysql-server mysql-server/root_password_again password rooot | debconf-set-selections
+# The following two lines prevent mysql from asking for a password (it will be set to $MYSQL_PASS)
+echo mysql-server mysql-server/root_password password $MYSQL_PW | debconf-set-selections
+echo mysql-server mysql-server/root_password_again password $MYSQL_PW | debconf-set-selections
 apt-get -y install maven mysql-server mysql-client automake libtool build-essential
 
 echo "Building OpenDF!"
@@ -21,15 +36,15 @@ mvn clean install
 echo "Setting up mysql!"
 # Setting up mysql
 service mysql start
-mysql -u root --password="rooot" --execute="CREATE DATABASE IF NOT EXISTS OpenDF;"
-mysql -u root --password="rooot" --execute="CREATE USER 'OpenDFU'@'localhost' IDENTIFIED BY '123';"
-mysql -u root --password="rooot" --execute="GRANT ALL PRIVILEGES ON OpenDF.* TO 'OpenDFU'@'localhost';"
-mysql -u root --password="rooot" OpenDF < db/OpenDF.sql
+mysql -u $MYSQL_USER --password="$MYSQL_PW" --execute="CREATE DATABASE IF NOT EXISTS OpenDF;"
+mysql -u $MYSQL_USER --password="$MYSQL_PW" --execute="CREATE USER '${OPENDF_DB_USER}'@'localhost' IDENTIFIED BY '${OPENDF_DB_PW}';"
+mysql -u $MYSQL_USER --password="$MYSQL_PW" --execute="GRANT ALL PRIVILEGES ON OpenDF.* TO '${OPENDF_DB_USER}'@'localhost';"
+mysql -u $MYSQL_USER --password="$MYSQL_PW" OpenDF < db/OpenDF.sql
 
 echo "Building dependencies!"
 # Build dependencies
 # Not using the build_sleuthkit script here as it is interactive
-git clone https://github.com/sleuthkit/sleuthkit.git sleuthkit_recent
+git clone $SLEUTHKIT_REPO sleuthkit_recent
 cd sleuthkit_recent
 ./bootstrap
 ./configure
@@ -53,6 +68,19 @@ asadmin deploy "OpenDF-ear/target/OpenDF-ear-1.0-SNAPSHOT.ear"
 
 echo "OpenDF succefully deployed on http://$(/sbin/ip route|awk '/default/ { print $3 }'):8080/OpenDF-web-1.0-SNAPSHOT"
 
+echo "Setting up Glashfish server!"
+asadmin restart-domain
+wget http://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.38.zip
+unzip mysql-connector-java-5.1.38.zip
+asadmin add-library --type ext mysql-connector-java-5.1.38/mysql-connector-java-5.1.38-bin.jar
+asadmin restart-domain
 
+echo "Deploying OpenDF to glassfish server!"
+# Deploy OpenDF to glassfish server
+# The glassfish bin directory should be in the $PATH.
+asadmin add-resources "OpenDF-ejb/src/main/setup/glassfish-resources.xml"
+asadmin add-resources "OpenDF-web/src/main/setup/glassfish-resources.xml"
 
+asadmin deploy "OpenDF-ear/target/OpenDF-ear-1.0-SNAPSHOT.ear"
 
+echo "OpenDF succefully deployed on http://$(/sbin/ip route|awk '/default/ { print $3 }'):8080/OpenDF-web"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -68,19 +68,4 @@ asadmin deploy "OpenDF-ear/target/OpenDF-ear-1.0-SNAPSHOT.ear"
 
 echo "OpenDF succefully deployed on http://$(/sbin/ip route|awk '/default/ { print $3 }'):8080/OpenDF-web-1.0-SNAPSHOT"
 
-echo "Setting up Glashfish server!"
-asadmin restart-domain
-wget http://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.38.zip
-unzip mysql-connector-java-5.1.38.zip
-asadmin add-library --type ext mysql-connector-java-5.1.38/mysql-connector-java-5.1.38-bin.jar
-asadmin restart-domain
 
-echo "Deploying OpenDF to glassfish server!"
-# Deploy OpenDF to glassfish server
-# The glassfish bin directory should be in the $PATH.
-asadmin add-resources "OpenDF-ejb/src/main/setup/glassfish-resources.xml"
-asadmin add-resources "OpenDF-web/src/main/setup/glassfish-resources.xml"
-
-asadmin deploy "OpenDF-ear/target/OpenDF-ear-1.0-SNAPSHOT.ear"
-
-echo "OpenDF succefully deployed on http://$(/sbin/ip route|awk '/default/ { print $3 }'):8080/OpenDF-web"


### PR DESCRIPTION
Added support for taking environment variables from docker.
Supported are:
* SLEUTHKIT_REPO (URL of sleuthkit repository)
* MYSQL_USER
* MYSQL_PW
* OPENDF_DB_USER (Database user's name for the OpenDF database)
* OPENDF_DB_PW (Database user's password for the OpenDF database)

If a value isn't set, the script has/generates a default value. For the passwords (*_PW) this means that a pseudo-random password is being generated, which is printed to stdout at the end of the build process in a line starting with [INFO]. This way, every installation generates its own 'default' passwords which is more secure than a hardcoded one.