### PR TITLE
Use bcrypt to hash passwords

### DIFF
--- a/OpenDF-web/pom.xml
+++ b/OpenDF-web/pom.xml
@@ -50,6 +50,12 @@
             <artifactId>Tsk_DataModel</artifactId>
             <version>4.1.5</version>
         </dependency>
+        <!-- bcrypt hashing -->
+        <dependency>
+            <groupId>org.mindrot</groupId>
+            <artifactId>jbcrypt</artifactId>
+            <version>0.3m</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/OpenDF-web/src/main/java/lk/ucsc/score/apps/service/UserFacadeREST.java
+++ b/OpenDF-web/src/main/java/lk/ucsc/score/apps/service/UserFacadeREST.java
@@ -21,7 +21,9 @@ import javax.ws.rs.FormParam;
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Context;
+import lk.ucsc.score.apps.UserLogin;
 import lk.ucsc.score.apps.uploaders.Validator;
+import org.mindrot.jbcrypt.BCrypt;
 /**
  *
  * @author Acer
@@ -96,8 +98,8 @@ public class UserFacadeREST extends AbstractFacade<User> {
         if(!password.equals(repassword) ){ throw new ServiceException(500, "Passwords do not match"); }
         if(password.length() <  8 ){ throw new ServiceException(500, "Password too short"); }
         if(password.length() > 30 ){ throw new ServiceException(500, "Password too long"); }
-        User user =  em.find(User.class, (Integer)idUser);
-        user.setPassword(password);
+        User user = em.find(User.class, (Integer)idUser);
+        user.setPassword(UserLogin.HASHED_PASSWORD_PREFIX + BCrypt.hashpw(password, BCrypt.gensalt()));
         em.persist(user);
     }
     


### PR DESCRIPTION
This adds bcrypt password hashing support while maintaining backwards-compatibility with plaintext passwords in the database.
Current passwords will still allow the user to login, and when they next changes their password it will be stored in the database as a bcrypt hash (with a cost factor of 10, or 1024 rounds).