### PR TITLE
Add thumbnail view for files

### DIFF
--- a/OpenDF-web/src/main/webapp/css/styles.css
+++ b/OpenDF-web/src/main/webapp/css/styles.css
@@ -425,3 +425,7 @@ background-color: #F5F5F5;
     margin-right: 10px;
     margin-bottom: 10px;
 }
+.file-thumbnail-image {
+    height: 110px;
+    background-size: cover;
+}

--- a/OpenDF-web/src/main/webapp/css/styles.css
+++ b/OpenDF-web/src/main/webapp/css/styles.css
@@ -418,3 +418,10 @@ background-color: #F5F5F5;
     padding: 10px;
     text-align: center;
 }
+
+.file-thumbs {
+    width: 200px;
+    float: left;
+    margin-right: 10px;
+    margin-bottom: 10px;
+}

--- a/OpenDF-web/src/main/webapp/img/document.svg
+++ b/OpenDF-web/src/main/webapp/img/document.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="168"
+   height="110"
+   viewBox="0 0 168 110"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="document.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8"
+     inkscape:cx="-29.579318"
+     inkscape:cy="29.789652"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1043"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-942.36214)">
+    <path
+       style="fill:none;fill-opacity:1;stroke:#b9b9b9;stroke-width:4.42101002;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 110.1467,973.59143 0,60.17607 -51.092855,0 0,-73.42237 37.08963,0 z"
+       id="rect4684"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       inkscape:connector-type="polyline"
+       id="path4708-9"
+       d="m 69.022403,989.38482 31.101087,-0.0109"
+       style="fill:none;fill-rule:evenodd;stroke:#b9b9b9;stroke-width:4.42101002;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       inkscape:connector-type="polyline"
+       id="path4708-8"
+       d="m 69.022398,1018.2561 31.101092,-0.011"
+       style="fill:none;fill-rule:evenodd;stroke:#b9b9b9;stroke-width:4.42101002;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#b9b9b9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 95.253722,962.50704 c -0.189232,1.13539 -0.03345,12.12991 -0.03345,12.12991 l 13.592125,0.004 z"
+       id="path4763"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#b9b9b9;stroke-width:4.42101002;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 69.022403,1004.4421 31.101087,-0.011"
+       id="path4157"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       inkscape:connector-type="polyline"
+       id="path4708-9-6"
+       d="m 69.0224,974.34842 19.584839,-0.0746"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#b9b9b9;stroke-width:4.42101002;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/OpenDF-web/src/main/webapp/js/dashboard.js
+++ b/OpenDF-web/src/main/webapp/js/dashboard.js
@@ -204,7 +204,7 @@ OpenDFApp.controller('notesController', ['$scope', '$routeParams', 'notesFactory
             $scope.notes  = notes;
         });
         $scope.isFileType = function(name, types){
-            return !$.inArray(name.match(/\.[0-9a-z]{1,5}$/i)[0], types);
+            return types.indexOf(name.match(/\.[0-9a-z]{1,5}$/i)[0]) >= 0;
         }
         $scope.hasFileType = function(name){
             return name.match(/\.[0-9a-z]{1,5}$/i)!=null;
@@ -322,7 +322,7 @@ OpenDFApp.controller('filesController', ['$scope', '$location', '$routeParams' ,
             });
         }
         $scope.isFileType = function(name, types){
-            return !$.inArray(name.match(/\.[0-9a-z]{1,5}$/i)[0], types);
+            return types.indexOf(name.match(/\.[0-9a-z]{1,5}$/i)[0]) >= 0;
         }
         $scope.hasFileType = function(name){
             return name.match(/\.[0-9a-z]{1,5}$/i)!=null;
@@ -336,7 +336,7 @@ OpenDFApp.directive('dfThumbBackgroundImage', function () {
         },
         link: function (scope, elem, attrs) {
             function isFileType(name, types) {
-                return !$.inArray(name.match(/\.[0-9a-z]{1,5}$/i)[0], types);
+                return types.indexOf(name.match(/\.[0-9a-z]{1,5}$/i)[0]) >= 0;
             }
             scope.$watch('dfThumbBackgroundImage', function (file) {
                 var isImage = isFileType(file.name, ['.png', '.jpg', '.jpeg', '.gif', '.tif']);

--- a/OpenDF-web/src/main/webapp/js/dashboard.js
+++ b/OpenDF-web/src/main/webapp/js/dashboard.js
@@ -204,7 +204,7 @@ OpenDFApp.controller('notesController', ['$scope', '$routeParams', 'notesFactory
             $scope.notes  = notes;
         });
         $scope.isFileType = function(name, types){
-            return types.indexOf(name.match(/\.[0-9a-z]{1,5}$/i)[0]) >= 0;
+            return types.indexOf((name.match(/\.[0-9a-z]{1,5}$/i) || [undefined])[0]) >= 0;
         }
         $scope.hasFileType = function(name){
             return name.match(/\.[0-9a-z]{1,5}$/i)!=null;
@@ -307,7 +307,10 @@ services.factory('InvestigatorsFactory', function ($resource) {
         })
 });
 OpenDFApp.controller('filesController', ['$scope', '$location', '$routeParams' , 'DiskImagesFactory', function ($scope, $location, $routeParams, DiskImagesFactory) {
-       $scope.displayType = 'thumbs';
+        $scope.displayFormat = localStorage.fileDisplayFormat || 'link';
+        $scope.$watch('displayFormat', function() {
+            localStorage.fileDisplayFormat = $scope.displayFormat;
+        })
        
         $scope.getFilesByHierarchy = function(){
             DiskImagesFactory.getFile({ id: $routeParams.idProject,  idFile: $routeParams.idFile  }, function(data) {
@@ -322,7 +325,7 @@ OpenDFApp.controller('filesController', ['$scope', '$location', '$routeParams' ,
             });
         }
         $scope.isFileType = function(name, types){
-            return types.indexOf(name.match(/\.[0-9a-z]{1,5}$/i)[0]) >= 0;
+            return types.indexOf((name.match(/\.[0-9a-z]{1,5}$/i) || [undefined])[0]) >= 0;
         }
         $scope.hasFileType = function(name){
             return name.match(/\.[0-9a-z]{1,5}$/i)!=null;
@@ -336,11 +339,10 @@ OpenDFApp.directive('dfThumbBackgroundImage', function () {
         },
         link: function (scope, elem, attrs) {
             function isFileType(name, types) {
-                return types.indexOf(name.match(/\.[0-9a-z]{1,5}$/i)[0]) >= 0;
+                return types.indexOf((name.match(/\.[0-9a-z]{1,5}$/i) || [undefined])[0]) >= 0;
             }
             scope.$watch('dfThumbBackgroundImage', function (file) {
                 var isImage = isFileType(file.name, ['.png', '.jpg', '.jpeg', '.gif', '.tif']);
-                console.log('file', file, isImage);
                 if (isImage) {
                     elem.css({
                         'background-image': 'url(ServeFile?idFile=' + file.idFile + ')',

--- a/OpenDF-web/src/main/webapp/js/dashboard.js
+++ b/OpenDF-web/src/main/webapp/js/dashboard.js
@@ -307,6 +307,7 @@ services.factory('InvestigatorsFactory', function ($resource) {
         })
 });
 OpenDFApp.controller('filesController', ['$scope', '$location', '$routeParams' , 'DiskImagesFactory', function ($scope, $location, $routeParams, DiskImagesFactory) {
+       $scope.displayType = 'thumbs';
        
         $scope.getFilesByHierarchy = function(){
             DiskImagesFactory.getFile({ id: $routeParams.idProject,  idFile: $routeParams.idFile  }, function(data) {
@@ -328,6 +329,30 @@ OpenDFApp.controller('filesController', ['$scope', '$location', '$routeParams' ,
         }
         
 }]);
+OpenDFApp.directive('dfThumbBackgroundImage', function () {
+    return {
+        scope: {
+            dfThumbBackgroundImage: '='
+        },
+        link: function (scope, elem, attrs) {
+            function isFileType(name, types) {
+                return !$.inArray(name.match(/\.[0-9a-z]{1,5}$/i)[0], types);
+            }
+            scope.$watch('dfThumbBackgroundImage', function (file) {
+                var isImage = isFileType(file.name, ['.png', '.jpg', '.jpeg', '.gif', '.tif']);
+                console.log('file', file, isImage);
+                if (isImage) {
+                    elem.css({
+                        'background-image': 'url(ServeFile?idFile=' + file.idFile + ')',
+                        'background-size': 'cover'
+                    });
+                } else {
+                    elem.css({'background-image': ''});
+                }
+            });
+        }
+    };
+});
 services.factory('filesFactory', function ($resource) {
     return $resource('api/projects/:id/files/', {id: '@_id'}, {})
 });

--- a/OpenDF-web/src/main/webapp/js/dashboard.js
+++ b/OpenDF-web/src/main/webapp/js/dashboard.js
@@ -83,11 +83,13 @@ OpenDFApp.config(['$routeProvider',
 OpenDFApp.controller('dashboardController', ['$scope', '$location', '$routeParams','ProjectsFactory', 'BackboneService', '$rootScope', function ($scope, $location, $routeParams, ProjectsFactory, BackboneService, $rootScope) {
         BackboneService.id = $routeParams.idProject;
         $rootScope.idProject = $routeParams.idProject;
-        ProjectsFactory.get({ id: $routeParams.idProject }, function(data) {
-            $scope.project = data;
-            console.log($scope.project);
-            $rootScope.sectionTitle = $scope.project.name;
-        }); 
+        if($routeParams.idProject) {
+            ProjectsFactory.get({ id: $routeParams.idProject }, function(data) {
+                $scope.project = data;
+                console.log($scope.project);
+                $rootScope.sectionTitle = $scope.project.name;
+            });
+        }
 }]);
 OpenDFApp.controller('processesController', ['$scope', '$location' , 'BackboneService', function ($scope, $location, BackboneService) {
         $scope.processes = BackboneService.prosecces;

--- a/OpenDF-web/src/main/webapp/js/dashboard.js
+++ b/OpenDF-web/src/main/webapp/js/dashboard.js
@@ -345,11 +345,12 @@ OpenDFApp.directive('dfThumbBackgroundImage', function () {
                 var isImage = isFileType(file.name, ['.png', '.jpg', '.jpeg', '.gif', '.tif']);
                 if (isImage) {
                     elem.css({
-                        'background-image': 'url(ServeFile?idFile=' + file.idFile + ')',
-                        'background-size': 'cover'
+                        'background-image': 'url(ServeFile?idFile=' + file.idFile + ')'
                     });
                 } else {
-                    elem.css({'background-image': ''});
+                    elem.css({
+                        'background-image': 'url(img/document.svg)'
+                    });
                 }
             });
         }

--- a/OpenDF-web/src/main/webapp/templates/dashboard/browse-by-hierarchy.htm
+++ b/OpenDF-web/src/main/webapp/templates/dashboard/browse-by-hierarchy.htm
@@ -20,13 +20,16 @@
     <div class="list-group" ng-controller="filesController" ng-init="getFilesByHierarchy()">
         <a  class="list-group-item" ng-if="displayType === 'list'"  ng-repeat="fl in file.childrenCollection" ng-click="(!fl.isDir)?false:goto('/'+idProject+'/browse-by-hierarchy/'+fl.idFile)">
             <h4 class="list-group-item-heading" ng-if="fl.name !=''">
-                <span ng-if="fl.isDir"> <i class="fa fa-folder-o"></i></span>		
-                <span ng-if="!fl.isDir && hasFileType(fl.name)"> 		
+                <span ng-if="fl.isDir"> <i class="fa fa-folder-o"></i></span>
+                <span ng-if="!fl.isDir && hasFileType(fl.name)">
                     <i class="fa fa-file-audio-o" ng-show="isFileType(fl.name,['.mp3','.wma'])"></i>
                     <i class="fa fa-file-pdf-o" ng-show="isFileType(fl.name,['.pdf'])"></i>
                     <i class="fa fa-file-archive-o" ng-show="isFileType(fl.name, ['.tar', '.zip', '.rar', '.7z', '.gz'])"></i>
                     <i class="fa fa-file-text" ng-show="isFileType(fl.name, ['.txt'])"></i>
                     <i class="fa fa-file-image-o" ng-show="isFileType(fl.name, ['.png', '.jpg', '.jpeg', '.gif', '.tif'])"></i>
+                    <i class="fa fa-file-word-o" ng-show="isFileType(fl.name, ['.odt', '.fodt', '.doc', '.dot', '.docx', '.docm', '.dotx', '.dotm', '.docb'])"></i>
+                    <i class="fa fa-file-excel-o" ng-show="isFileType(fl.name, ['.ods', '.fods', '.xls', '.xlt', '.xlm', '.xlsx', '.xlsm', '.xltx', '.xltm', '.xlw', '.xlsb'])"></i>
+                    <i class="fa fa-file-powerpoint-o" ng-show="isFileType(fl.name, ['.odp', '.fodp', '.ppt', '.pot', '.pps', '.pptx', '.pptm', '.potx', '.potm', '.ppam', '.ppsx', '.ppsm', '.sldx', '.sldm'])"></i>
                 </span>
                 <span ng-if="!fl.isDir && !hasFileType(fl.name)">
                     <i class="fa fa-file"></i>
@@ -48,9 +51,12 @@
                 <span ng-if="!fl.isDir && hasFileType(fl.name)">
                     <i class="fa fa-file-audio-o" ng-show="isFileType(fl.name,['.mp3','.wma'])"></i>
                     <i class="fa fa-file-pdf-o" ng-show="isFileType(fl.name,['.pdf'])"></i>
-                    <i class="fa fa-file-archive-o" ng-show="isFileType(fl.name,['.tar','.zip','.rar','.7z','.gz'])"></i>
-                    <i class="fa fa-file-text" ng-show="isFileType(fl.name,['.txt'])"></i>
-                    <i class="fa fa-file-image-o" ng-show="isFileType(fl.name,['.png', '.jpg', '.jpeg', '.gif', '.tif'])"></i>
+                    <i class="fa fa-file-archive-o" ng-show="isFileType(fl.name, ['.tar', '.zip', '.rar', '.7z', '.gz'])"></i>
+                    <i class="fa fa-file-text" ng-show="isFileType(fl.name, ['.txt'])"></i>
+                    <i class="fa fa-file-image-o" ng-show="isFileType(fl.name, ['.png', '.jpg', '.jpeg', '.gif', '.tif'])"></i>
+                    <i class="fa fa-file-word-o" ng-show="isFileType(fl.name, ['.odt', '.fodt', '.doc', '.dot', '.docx', '.docm', '.dotx', '.dotm', '.docb'])"></i>
+                    <i class="fa fa-file-excel-o" ng-show="isFileType(fl.name, ['.ods', '.fods', '.xls', '.xlt', '.xlm', '.xlsx', '.xlsm', '.xltx', '.xltm', '.xlw', '.xlsb'])"></i>
+                    <i class="fa fa-file-powerpoint-o" ng-show="isFileType(fl.name, ['.odp', '.fodp', '.ppt', '.pot', '.pps', '.pptx', '.pptm', '.potx', '.potm', '.ppam', '.ppsx', '.ppsm', '.sldx', '.sldm'])"></i>
                 </span>
                 <span ng-if="!fl.isDir && !hasFileType(fl.name)">
                     <i class="fa fa-file"></i>

--- a/OpenDF-web/src/main/webapp/templates/dashboard/browse-by-hierarchy.htm
+++ b/OpenDF-web/src/main/webapp/templates/dashboard/browse-by-hierarchy.htm
@@ -18,22 +18,46 @@
 
 <div id="content-wrapper" >
     <div class="list-group" ng-controller="filesController" ng-init="getFilesByHierarchy()">
-	<a  class="list-group-item"  ng-repeat="fl in file.childrenCollection" ng-click="(!fl.isDir)?false:goto('/'+idProject+'/browse-by-hierarchy/'+fl.idFile)">
-					
+        <a  class="list-group-item" ng-if="displayType === 'list'"  ng-repeat="fl in file.childrenCollection" ng-click="(!fl.isDir)?false:goto('/'+idProject+'/browse-by-hierarchy/'+fl.idFile)">
             <h4 class="list-group-item-heading" ng-if="fl.name !=''">
                 <span ng-if="fl.isDir"> <i class="fa fa-folder-o"></i></span>		
                 <span ng-if="!fl.isDir && hasFileType(fl.name)"> 		
-                <i class="fa fa-file-audio-o" ng-show="isFileType(fl.name,['.mp3','.wma'])"></i>			
-                <i class="fa fa-file-pdf-o" ng-show="isFileType(fl.name,['.pdf'])"></i>			
-                <i class="fa fa-file-archive-o" ng-show="isFileType(fl.name,['.tar','.zip','.rar','.7z','.gz'])"></i>			
-                <i class="fa fa-file-text" ng-show="isFileType(fl.name,['.txt'])"></i>			
-                <i class="fa fa-file-image-o" ng-show="isFileType(fl.name,['.png', '.jpg', '.jpeg', '.gif', '.tif'])"></i>			
+                    <i class="fa fa-file-audio-o" ng-show="isFileType(fl.name,['.mp3','.wma'])"></i>
+                    <i class="fa fa-file-pdf-o" ng-show="isFileType(fl.name,['.pdf'])"></i>
+                    <i class="fa fa-file-archive-o" ng-show="isFileType(fl.name, ['.tar', '.zip', '.rar', '.7z', '.gz'])"></i>
+                    <i class="fa fa-file-text" ng-show="isFileType(fl.name, ['.txt'])"></i>
+                    <i class="fa fa-file-image-o" ng-show="isFileType(fl.name, ['.png', '.jpg', '.jpeg', '.gif', '.tif'])"></i>
                 </span>
                 <span ng-if="!fl.isDir && !hasFileType(fl.name)">
                     <i class="fa fa-file"></i>
                 </span>
                 {{fl.name}}			
             </h4>
+            <h4 class="list-group-item-heading" ng-if="fl.name == ''"><i class="fa fa-file" ></i> $UNNAMED</h4>
+            <span class="list-group-item-text">Size: {{fl.size}}kb <i ng-if="fl.accessDate">Last access: {{fl.accessDate}}</i><i ng-if="fl.isVirtual">Virtual {{fl.isVirtual}}</i><i ng-if="fl.isDir">Dir: {{fl.isDir}}</i></span>
+            <div class="btn-group pull-right" role="group" aria-label="file-actions">
+                <button type="button" ng-hide="fl.isDir" id="{{fl.idFile}}" ng-click="viewer(fl)" class="btn btn-default btn-xs"><i class="fa fa-picture-o"> View</i></button>
+                <button type="button" ng-hide="fl.isDir" ng-click="goto('/'+idProject+'/bookmark/'+fl.idFile+'/in/'+fl.parentDirectory)" class="btn btn-default btn-xs"><i class="fa fa-bookmark"></i> +Note</button>
+                <button type="button" class="btn btn-default btn-xs"><i class="fa fa-chevron-down"></i> More </button>
+            </div>
+            <div class="image-viwer hidden" id="{{fl.idFile}}" ></div>
+        </a>
+        <a  class="list-group-item" ng-if="displayType === 'thumbs'" style="width: 200px; float: left; margin-right: 10px; margin-bottom: 10px;"  ng-repeat="fl in file.childrenCollection" ng-click="(!fl.isDir)?false:goto('/'+idProject+'/browse-by-hierarchy/'+fl.idFile)">
+            <h4 class="list-group-item-heading" ng-if="fl.name !=''">
+                <span ng-if="fl.isDir"> <i class="fa fa-folder-o"></i></span>
+                <span ng-if="!fl.isDir && hasFileType(fl.name)">
+                    <i class="fa fa-file-audio-o" ng-show="isFileType(fl.name,['.mp3','.wma'])"></i>
+                    <i class="fa fa-file-pdf-o" ng-show="isFileType(fl.name,['.pdf'])"></i>
+                    <i class="fa fa-file-archive-o" ng-show="isFileType(fl.name,['.tar','.zip','.rar','.7z','.gz'])"></i>
+                    <i class="fa fa-file-text" ng-show="isFileType(fl.name,['.txt'])"></i>
+                    <i class="fa fa-file-image-o" ng-show="isFileType(fl.name,['.png', '.jpg', '.jpeg', '.gif', '.tif'])"></i>
+                </span>
+                <span ng-if="!fl.isDir && !hasFileType(fl.name)">
+                    <i class="fa fa-file"></i>
+                </span>
+                {{fl.name}}
+            </h4>
+            <div style="height: 110px;" df-thumb-background-image="fl"></div>
             <h4 class="list-group-item-heading" ng-if="fl.name ==''"><i class="fa fa-file" ></i> $UNNAMED</h4>
             <span class="list-group-item-text">Size: {{fl.size}}kb <i ng-if="fl.accessDate">Last access: {{fl.accessDate}}</i><i ng-if="fl.isVirtual">Virtual {{fl.isVirtual}}</i><i ng-if="fl.isDir">Dir: {{fl.isDir}}</i></span>
             <div class="btn-group pull-right" role="group" aria-label="file-actions">

--- a/OpenDF-web/src/main/webapp/templates/dashboard/browse-by-hierarchy.htm
+++ b/OpenDF-web/src/main/webapp/templates/dashboard/browse-by-hierarchy.htm
@@ -40,7 +40,7 @@
                 </span>
                 {{fl.name}}			
             </h4>
-            <div style="height: 110px;" ng-if="displayFormat === 'thumbs'" df-thumb-background-image="fl"></div>
+            <div class="file-thumbnail-image" ng-if="displayFormat === 'thumbs'" df-thumb-background-image="fl"></div>
             <h4 class="list-group-item-heading" ng-if="fl.name == ''"><i class="fa fa-file" ></i> $UNNAMED</h4>
             <span class="list-group-item-text">Size: {{fl.size}}kb <i ng-if="fl.accessDate">Last access: {{fl.accessDate}}</i><i ng-if="fl.isVirtual">Virtual {{fl.isVirtual}}</i><i ng-if="fl.isDir">Dir: {{fl.isDir}}</i></span>
             <div class="btn-group pull-right" role="group" aria-label="file-actions">

--- a/OpenDF-web/src/main/webapp/templates/dashboard/browse-by-hierarchy.htm
+++ b/OpenDF-web/src/main/webapp/templates/dashboard/browse-by-hierarchy.htm
@@ -16,9 +16,13 @@
     <!-- /.navbar-static-side -->
 </nav>
 
-<div id="content-wrapper" >
-    <div class="list-group" ng-controller="filesController" ng-init="getFilesByHierarchy()">
-        <a  class="list-group-item" ng-if="displayType === 'list'"  ng-repeat="fl in file.childrenCollection" ng-click="(!fl.isDir)?false:goto('/'+idProject+'/browse-by-hierarchy/'+fl.idFile)">
+<div id="content-wrapper" ng-controller="filesController" ng-init="getFilesByHierarchy()">
+    <div class="btn-group" role="group" aria-label="..." style="margin-bottom: 20px;">
+        <button type="button" class="btn btn-default" ng-class="{active: displayFormat === 'list'}" ng-click="displayFormat = 'list'"><i class="fa fa-list"></i></button>
+        <button type="button" class="btn btn-default" ng-class="{active: displayFormat === 'thumbs'}" ng-click="displayFormat = 'thumbs'"><i class="fa fa-th"></i></button>
+    </div>
+    <div class="list-group">
+        <a  class="list-group-item" ng-class="'file-' + displayFormat" ng-repeat="fl in file.childrenCollection" ng-click="(!fl.isDir)?false:goto('/'+idProject+'/browse-by-hierarchy/'+fl.idFile)">
             <h4 class="list-group-item-heading" ng-if="fl.name !=''">
                 <span ng-if="fl.isDir"> <i class="fa fa-folder-o"></i></span>
                 <span ng-if="!fl.isDir && hasFileType(fl.name)">
@@ -36,6 +40,7 @@
                 </span>
                 {{fl.name}}			
             </h4>
+            <div style="height: 110px;" ng-if="displayFormat === 'thumbs'" df-thumb-background-image="fl"></div>
             <h4 class="list-group-item-heading" ng-if="fl.name == ''"><i class="fa fa-file" ></i> $UNNAMED</h4>
             <span class="list-group-item-text">Size: {{fl.size}}kb <i ng-if="fl.accessDate">Last access: {{fl.accessDate}}</i><i ng-if="fl.isVirtual">Virtual {{fl.isVirtual}}</i><i ng-if="fl.isDir">Dir: {{fl.isDir}}</i></span>
             <div class="btn-group pull-right" role="group" aria-label="file-actions">
@@ -45,34 +50,7 @@
             </div>
             <div class="image-viwer hidden" id="{{fl.idFile}}" ></div>
         </a>
-        <a  class="list-group-item" ng-if="displayType === 'thumbs'" style="width: 200px; float: left; margin-right: 10px; margin-bottom: 10px;"  ng-repeat="fl in file.childrenCollection" ng-click="(!fl.isDir)?false:goto('/'+idProject+'/browse-by-hierarchy/'+fl.idFile)">
-            <h4 class="list-group-item-heading" ng-if="fl.name !=''">
-                <span ng-if="fl.isDir"> <i class="fa fa-folder-o"></i></span>
-                <span ng-if="!fl.isDir && hasFileType(fl.name)">
-                    <i class="fa fa-file-audio-o" ng-show="isFileType(fl.name,['.mp3','.wma'])"></i>
-                    <i class="fa fa-file-pdf-o" ng-show="isFileType(fl.name,['.pdf'])"></i>
-                    <i class="fa fa-file-archive-o" ng-show="isFileType(fl.name, ['.tar', '.zip', '.rar', '.7z', '.gz'])"></i>
-                    <i class="fa fa-file-text" ng-show="isFileType(fl.name, ['.txt'])"></i>
-                    <i class="fa fa-file-image-o" ng-show="isFileType(fl.name, ['.png', '.jpg', '.jpeg', '.gif', '.tif'])"></i>
-                    <i class="fa fa-file-word-o" ng-show="isFileType(fl.name, ['.odt', '.fodt', '.doc', '.dot', '.docx', '.docm', '.dotx', '.dotm', '.docb'])"></i>
-                    <i class="fa fa-file-excel-o" ng-show="isFileType(fl.name, ['.ods', '.fods', '.xls', '.xlt', '.xlm', '.xlsx', '.xlsm', '.xltx', '.xltm', '.xlw', '.xlsb'])"></i>
-                    <i class="fa fa-file-powerpoint-o" ng-show="isFileType(fl.name, ['.odp', '.fodp', '.ppt', '.pot', '.pps', '.pptx', '.pptm', '.potx', '.potm', '.ppam', '.ppsx', '.ppsm', '.sldx', '.sldm'])"></i>
-                </span>
-                <span ng-if="!fl.isDir && !hasFileType(fl.name)">
-                    <i class="fa fa-file"></i>
-                </span>
-                {{fl.name}}
-            </h4>
-            <div style="height: 110px;" df-thumb-background-image="fl"></div>
-            <h4 class="list-group-item-heading" ng-if="fl.name ==''"><i class="fa fa-file" ></i> $UNNAMED</h4>
-            <span class="list-group-item-text">Size: {{fl.size}}kb <i ng-if="fl.accessDate">Last access: {{fl.accessDate}}</i><i ng-if="fl.isVirtual">Virtual {{fl.isVirtual}}</i><i ng-if="fl.isDir">Dir: {{fl.isDir}}</i></span>
-            <div class="btn-group pull-right" role="group" aria-label="file-actions">
-                <button type="button" ng-hide="fl.isDir" id="{{fl.idFile}}" ng-click="viewer(fl)" class="btn btn-default btn-xs"><i class="fa fa-picture-o"> View</i></button>
-                <button type="button" ng-hide="fl.isDir" ng-click="goto('/'+idProject+'/bookmark/'+fl.idFile+'/in/'+fl.parentDirectory)" class="btn btn-default btn-xs"><i class="fa fa-bookmark"></i> +Note</button>
-                <button type="button" class="btn btn-default btn-xs"><i class="fa fa-chevron-down"></i> More </button>
-            </div>
-            <div class="image-viwer hidden" id="{{fl.idFile}}" ></div>
-        </a>
+        <div style="clear: both"></div>
     </div>
 </div>
 <div id="myModal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">

--- a/OpenDF-web/src/main/webapp/templates/dashboard/disk-images-add-new.htm
+++ b/OpenDF-web/src/main/webapp/templates/dashboard/disk-images-add-new.htm
@@ -29,7 +29,7 @@
                             <form role="form"  name="addNewDiskImage" ng-submit="addNew()" ng-init="">
                                 <div class="form-group">
                                     <label>Disk image name</label>
-                                    <input class="form-control" placeholder="Enter case name" ng-model="diskImage.name" required>
+                                    <input class="form-control" placeholder="Enter disk image name" ng-model="diskImage.name" required>
                                 </div>
                                 <div class="form-group">
                                     <label>Disk image Description</label>


### PR DESCRIPTION
Adds a thumbnail view with buttons above the list to give the user a choice between it and the default list view.
The user's choice is persisted to HTML5 local storage so that the format stays the same if they refresh or use the site later.

The pull request also adds a few new file type icons, and fixes a bug where the icon was only displayed if the file ended with the extension that was first in the list.