### PR TITLE
Add authentication to ProjectFacadeRest

### DIFF
--- a/OpenDF-web/src/main/java/lk/ucsc/score/apps/Authentication.java
+++ b/OpenDF-web/src/main/java/lk/ucsc/score/apps/Authentication.java
@@ -1,0 +1,47 @@
+package lk.ucsc.score.apps;
+
+import javax.persistence.EntityManager;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import lk.ucsc.score.apps.models.User;
+import lk.ucsc.score.apps.service.ServiceException;
+
+/**
+ *
+ * @author lucasjones
+ */
+public class Authentication {
+
+    public static Object getUserId(HttpServletRequest request) {
+        HttpSession session = request.getSession();
+        if (session == null) {
+            return null;
+        }
+        return session.getAttribute("user");
+    }
+
+    public static boolean userHasAccess(HttpServletRequest request) {
+        return getUserId(request) != null;
+    }
+
+    public static boolean userIsAdmin(HttpServletRequest request, EntityManager em) {
+        Object userId = getUserId(request);
+        User user = em.find(User.class, userId);
+        if (user == null) {
+            return false;
+        }
+        return user.getLevel() == 0;
+    }
+
+    public static void assertUserHasAccess(HttpServletRequest request) {
+        if(!userHasAccess(request)) {
+            throw new ServiceException(401, "Unauthorized");
+        }
+    }
+
+    public static void assertUserIsAdmin(HttpServletRequest request, EntityManager em) {
+        if(!userIsAdmin(request, em)) {
+            throw new ServiceException(401, "Insufficient access level");
+        }
+    }
+}


### PR DESCRIPTION
Authenticates calls made to the ProjectFacadeRest, verifying that the user is logged in, has access to the project or is an administrator depending on the endpoint.

The authentication is done by calling methods in Authentication.java (e.g. `Authentication.assertUserIsAdmin()`), which will throw a relevant ServiceException if the user does not have the required permissions to access the resource.

I am planning to add authentication to the other API endpoints soon (in UserFacadeRest, etc)
